### PR TITLE
画像スライダーバグ修正

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,10 +10,10 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
-//= require jquery
 //= require bootstrap-sprockets
 //= require_tree .
 //= require moment
@@ -21,62 +21,52 @@
 //= require chartkick
 //= require Chart.bundle
 
- $(document).on('turbolinks:load', function () {
+
+$(document).on('turbolinks:load', function () {
+    if($('.slider').hasClass('slick-initialized')){
+    // カレンダーページから他のページに飛び、ブラウザバックを行ったとき、slickが二回呼び起こされ、再度読み込まれないバグが発生しました。
+    // slick-initializedに原因があるらしく対処しましたが、どの方法も受け付けなかったので、ブラウザバックでslick-initializedが呼び出された時は強制的にリロードするようにしました。
+        window.location.reload();
+    }
     $('.slider').slick({
         autoplay: true,
-        autoplaySpeed: 10000,
+        autoplaySpeed: 10000
     });
+
+    // lengthを呼び出すことで、#calendarが存在していた場合はtrueの処理がされ、無い場合はnillを返す
+    if ($('#calendar').length) {
+        function eventCalendar() {
+            return $('#calendar').fullCalendar({
+            });
+        };
+        function clearCalendar() {
+            $('#calendar').html('');
+        };
+        $(document).on('turbolinks:before-cache', clearCalendar);
+
+        $('#calendar').fullCalendar({
+            events: '/events.json',
+            titleFormat: 'YYYY年 M月',
+            dayNamesShort: ['日', '月', '火', '水', '木', '金', '土'],
+            header: {
+                left: '',
+                center: 'title',
+                right: 'today prev,next'
+            },
+            defaultTimedEventDuration: '03:00:00',
+            buttonText: {
+                prev: '前',
+                next: '次',
+                prevYear: '前年',
+                nextYear: '翌年',
+                today: '今日',
+                month: '月',
+                week: '週',
+                day: '日'
+            },
+            timeFormat: "HH:mm",
+            eventColor: 'gray',
+            eventTextColor: '#FFFFFF',
+        });
+    }
 });
-
-
-
-
-    $(document).on('turbolinks:load', function () {
-        // lengthを呼び出すことで、#calendarが存在していた場合はtrueの処理がされ、無い場合はnillを返す
-        if ($('#calendar').length) {
-            function eventCalendar() {
-                return $('#calendar').fullCalendar({
-                });
-            };
-            function clearCalendar() {
-                $('#calendar').html('');
-            };
-
-            $(document).on('turbolinks:load', function () {
-                eventCalendar();
-            });
-            $(document).on('turbolinks:before-cache', clearCalendar);
-
-            $('#calendar').fullCalendar({
-                events: '/events.json',
-                //カレンダー上部を年月で表示させる
-                titleFormat: 'YYYY年 M月',
-                //曜日を日本語表示
-                dayNamesShort: ['日', '月', '火', '水', '木', '金', '土'],
-                //ボタンのレイアウト
-                header: {
-                    left: '',
-                    center: 'title',
-                    right: 'today prev,next'
-                },
-                //終了時刻がないイベントの表示間隔
-                defaultTimedEventDuration: '03:00:00',
-                buttonText: {
-                    prev: '前',
-                    next: '次',
-                    prevYear: '前年',
-                    nextYear: '翌年',
-                    today: '今日',
-                    month: '月',
-                    week: '週',
-                    day: '日'
-                },
-                //イベントの時間表示を２４時間に
-                timeFormat: "HH:mm",
-                //イベントの色を変える
-                eventColor: 'gray',
-                //イベントの文字色を変える
-                eventTextColor: '#FFFFFF',
-            });
-        }
-    });


### PR DESCRIPTION
カレンダーページから他のページに飛び、ブラウザバックを行ったとき、slickが二回呼び起こされ、再度読み込まれないバグが発生しました。slick-initializedに原因があるらしく対処しましたが、どの方法も受け付けなかったので、ブラウザバックでslick-initializedが呼び出された時は強制的にリロードするようにしました。